### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/README.md
+++ b/dependency-matrix/README.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[manuelwallrapp/wzu-jx-1](https://github.com/manuelwallrapp/wzu-jx-1.git) |  | []() | 
+[manuelwallrapp/wzu-jx-2](https://github.com/manuelwallrapp/wzu-jx-2.git) |  | []() | 

--- a/dependency-matrix/README.md
+++ b/dependency-matrix/README.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[manuelwallrapp/wzu-jx-2](https://github.com/manuelwallrapp/wzu-jx-2.git) |  | []() | 
+[manuelwallrapp/wzu-jx-3](https://github.com/manuelwallrapp/wzu-jx-3.git) |  | []() | 

--- a/dependency-matrix/README.md
+++ b/dependency-matrix/README.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[manuelwallrapp/wzu-jx-3](https://github.com/manuelwallrapp/wzu-jx-3.git) |  | []() | 
+[manuelwallrapp/wzu-jx-4](https://github.com/manuelwallrapp/wzu-jx-4.git) |  | []() | 

--- a/dependency-matrix/README.md
+++ b/dependency-matrix/README.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[manuelwallrapp/wzu-jx-1](https://github.com/manuelwallrapp/wzu-jx-1.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: manuelwallrapp
-  repo: wzu-jx-2
-  url: https://github.com/manuelwallrapp/wzu-jx-2.git
+  repo: wzu-jx-3
+  url: https://github.com/manuelwallrapp/wzu-jx-3.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: manuelwallrapp
+  repo: wzu-jx-1
+  url: https://github.com/manuelwallrapp/wzu-jx-1.git
+  version: ""
+  versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: manuelwallrapp
-  repo: wzu-jx-3
-  url: https://github.com/manuelwallrapp/wzu-jx-3.git
+  repo: wzu-jx-4
+  url: https://github.com/manuelwallrapp/wzu-jx-4.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: manuelwallrapp
-  repo: wzu-jx-1
-  url: https://github.com/manuelwallrapp/wzu-jx-1.git
+  repo: wzu-jx-2
+  url: https://github.com/manuelwallrapp/wzu-jx-2.git
   version: ""
   versionURL: ""

--- a/repositories/templates/manuelwallrapp-wzu-jx-1-sr.yaml
+++ b/repositories/templates/manuelwallrapp-wzu-jx-1-sr.yaml
@@ -1,0 +1,48 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: manuelwallrapp
+    provider: github
+    repository: wzu-jx-1
+  managedFields:
+  - apiVersion: jenkins.io/v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          .: {}
+          f:owner: {}
+          f:provider: {}
+          f:repository: {}
+      f:spec:
+        .: {}
+        f:description: {}
+        f:httpCloneURL: {}
+        f:org: {}
+        f:provider: {}
+        f:providerKind: {}
+        f:providerName: {}
+        f:repo: {}
+        f:scheduler:
+          .: {}
+          f:kind: {}
+          f:name: {}
+        f:url: {}
+    manager: jx
+    operation: Update
+    time: "2020-11-12T16:29:38Z"
+  name: manuelwallrapp-wzu-jx-1
+spec:
+  description: Imported application for manuelwallrapp/wzu-jx-1
+  httpCloneURL: https://github.com/manuelwallrapp/wzu-jx-1.git
+  org: manuelwallrapp
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: wzu-jx-1
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/manuelwallrapp/wzu-jx-1.git

--- a/repositories/templates/manuelwallrapp-wzu-jx-2-sr.yaml
+++ b/repositories/templates/manuelwallrapp-wzu-jx-2-sr.yaml
@@ -1,0 +1,48 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: manuelwallrapp
+    provider: github
+    repository: wzu-jx-2
+  managedFields:
+  - apiVersion: jenkins.io/v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          .: {}
+          f:owner: {}
+          f:provider: {}
+          f:repository: {}
+      f:spec:
+        .: {}
+        f:description: {}
+        f:httpCloneURL: {}
+        f:org: {}
+        f:provider: {}
+        f:providerKind: {}
+        f:providerName: {}
+        f:repo: {}
+        f:scheduler:
+          .: {}
+          f:kind: {}
+          f:name: {}
+        f:url: {}
+    manager: jx
+    operation: Update
+    time: "2020-11-12T16:41:51Z"
+  name: manuelwallrapp-wzu-jx-2
+spec:
+  description: Imported application for manuelwallrapp/wzu-jx-2
+  httpCloneURL: https://github.com/manuelwallrapp/wzu-jx-2.git
+  org: manuelwallrapp
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: wzu-jx-2
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/manuelwallrapp/wzu-jx-2.git

--- a/repositories/templates/manuelwallrapp-wzu-jx-3-sr.yaml
+++ b/repositories/templates/manuelwallrapp-wzu-jx-3-sr.yaml
@@ -1,0 +1,48 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: manuelwallrapp
+    provider: github
+    repository: wzu-jx-3
+  managedFields:
+  - apiVersion: jenkins.io/v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          .: {}
+          f:owner: {}
+          f:provider: {}
+          f:repository: {}
+      f:spec:
+        .: {}
+        f:description: {}
+        f:httpCloneURL: {}
+        f:org: {}
+        f:provider: {}
+        f:providerKind: {}
+        f:providerName: {}
+        f:repo: {}
+        f:scheduler:
+          .: {}
+          f:kind: {}
+          f:name: {}
+        f:url: {}
+    manager: jx
+    operation: Update
+    time: "2020-11-13T07:47:35Z"
+  name: manuelwallrapp-wzu-jx-3
+spec:
+  description: Imported application for manuelwallrapp/wzu-jx-3
+  httpCloneURL: https://github.com/manuelwallrapp/wzu-jx-3.git
+  org: manuelwallrapp
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: wzu-jx-3
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/manuelwallrapp/wzu-jx-3.git

--- a/repositories/templates/manuelwallrapp-wzu-jx-4-sr.yaml
+++ b/repositories/templates/manuelwallrapp-wzu-jx-4-sr.yaml
@@ -1,0 +1,48 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: manuelwallrapp
+    provider: github
+    repository: wzu-jx-4
+  managedFields:
+  - apiVersion: jenkins.io/v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          .: {}
+          f:owner: {}
+          f:provider: {}
+          f:repository: {}
+      f:spec:
+        .: {}
+        f:description: {}
+        f:httpCloneURL: {}
+        f:org: {}
+        f:provider: {}
+        f:providerKind: {}
+        f:providerName: {}
+        f:repo: {}
+        f:scheduler:
+          .: {}
+          f:kind: {}
+          f:name: {}
+        f:url: {}
+    manager: jx
+    operation: Update
+    time: "2020-11-18T10:52:36Z"
+  name: manuelwallrapp-wzu-jx-4
+spec:
+  description: Imported application for manuelwallrapp/wzu-jx-4
+  httpCloneURL: https://github.com/manuelwallrapp/wzu-jx-4.git
+  org: manuelwallrapp
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: wzu-jx-4
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/manuelwallrapp/wzu-jx-4.git


### PR DESCRIPTION
Update [manuelwallrapp/wzu-jx-4](https://github.com/manuelwallrapp/wzu-jx-4.git) 

Command run was `jx create quickstart`
<hr />

Update [manuelwallrapp/wzu-jx-3](https://github.com/manuelwallrapp/wzu-jx-3.git) 

Command run was `jx create quickstart`
<hr />

Update [manuelwallrapp/wzu-jx-2](https://github.com/manuelwallrapp/wzu-jx-2.git) 

Command run was `jx create quickstart`
<hr />

Update [manuelwallrapp/wzu-jx-1](https://github.com/manuelwallrapp/wzu-jx-1.git) 

Command run was `jx create quickstart`